### PR TITLE
Design/card component

### DIFF
--- a/components/card/Checkbox.tsx
+++ b/components/card/Checkbox.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { IconType } from 'react-icons';
+
+interface CheckboxProps {
+  targetState: boolean;
+  buttonIcon: IconType;
+  handleCheckbox: (event: React.MouseEvent<HTMLLabelElement>) => void;
+}
+
+export default function Checkbox({ targetState, buttonIcon, handleCheckbox }: CheckboxProps) {
+  const ButtonIcon = buttonIcon;
+  const [checkedState, setCheckedState] = React.useState<boolean>(false);
+
+  function handleChange() {
+    setCheckedState(targetState);
+  }
+
+  return (
+    <label htmlFor='checkbox' onClick={handleCheckbox}>
+      <input
+        name='checkbox'
+        type='checkbox'
+        className='hidden'
+        checked={checkedState}
+        onChange={handleChange}
+      />
+      <ButtonIcon
+        className={`text-xl cursor-pointer ${targetState ? 'fill-yellow-300' : 'fill-gray-200'}`}
+      />
+    </label>
+  );
+}

--- a/components/card/hooks/useDerivedStateFromProps.ts
+++ b/components/card/hooks/useDerivedStateFromProps.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const useDerivedStateFromProps = <T>(
+  propsToMakeState: T
+): [T, React.Dispatch<React.SetStateAction<T>>] => {
+  const [stateToDifferentiate, setState] = React.useState<T | null>(null);
+
+  React.useEffect(() => {
+    if (propsToMakeState !== stateToDifferentiate) setState(propsToMakeState);
+  }, []);
+
+  return [stateToDifferentiate as T, setState as React.Dispatch<React.SetStateAction<T>>];
+};
+
+export default useDerivedStateFromProps;

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -23,15 +23,31 @@ export default function Card({ cardData }: CardProps) {
         ...cardData,
         isRead: true,
         isFavorite: favoriteState,
-      }
+      };
       axios.patch('/feed', newData);
       if (link) window.location.assign(link);
     }
   }
 
-  function handleCheckbox<T>(originalState: boolean, callback: CallbackType) {
+  function handleFavorite<T>(originalState: boolean, callback: CallbackType) {
     return function (event: React.MouseEvent<T>) {
       callback(!originalState);
+      const newData = {
+        ...cardData,
+        isFavorite: !originalState,
+      };
+      axios.patch('/feed', newData);
+    };
+  }
+
+  function handleRead<T>(originalState: boolean, callback: CallbackType) {
+    return function (event: React.MouseEvent<T>) {
+      callback(!originalState);
+      const newData = {
+        ...cardData,
+        isRead: !originalState,
+      };
+      axios.patch('/feed', newData);
     };
   }
 
@@ -54,7 +70,7 @@ export default function Card({ cardData }: CardProps) {
         <Checkbox
           targetState={favoriteState}
           buttonIcon={FavoriteIcon}
-          handleCheckbox={handleCheckbox(favoriteState, setFavoriteState)}
+          handleCheckbox={handleFavorite(favoriteState, setFavoriteState)}
         />
       </div>
       <div>
@@ -63,7 +79,7 @@ export default function Card({ cardData }: CardProps) {
           <Checkbox
             targetState={readState}
             buttonIcon={CheckIcon}
-            handleCheckbox={handleCheckbox(readState, setReadState)}
+            handleCheckbox={handleRead(readState, setReadState)}
           />
         </div>
         <p className='my-3'>{description}</p>

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { AiFillStar as FavoriteIcon, AiFillRead as CheckIcon } from 'react-icons/ai';
+import { FeedsObjectType } from 'types/global';
+import useDerivedStateFromProps from './hooks/useDerivedStateFromProps';
+import Checkbox from './Checkbox';
+
+type CardProps = {
+  cardData: FeedsObjectType;
+};
+
+type CallbackType = (value: any) => void;
+
+export default function Card({ cardData }: CardProps) {
+  const { id, title, description, link, pubDate, origin, isRead, isFavorite } = cardData;
+  const parsedPubDate = new Date(pubDate as string).toDateString();
+  const [readState, setReadState] = useDerivedStateFromProps<boolean>(isRead);
+  const [favoriteState, setFavoriteState] = useDerivedStateFromProps<boolean>(isFavorite);
+
+  function handleCard(event: React.MouseEvent) {
+    if (!(event.target instanceof SVGElement)) {
+      if (link) window.location.assign(link);
+      setReadState(true);
+    }
+  }
+
+  function handleCheckbox<T>(originalState: boolean, callback: CallbackType) {
+    return function (event: React.MouseEvent<T>) {
+      callback(!originalState);
+    };
+  }
+
+  return (
+    <section
+      className='flex rounded-md shadow-lg px-6 py-4 bg-neutral-100 text-black cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200'
+      onClick={handleCard}
+    >
+      <div className='mr-4 py-1'>
+        <Checkbox
+          targetState={favoriteState}
+          buttonIcon={FavoriteIcon}
+          handleCheckbox={handleCheckbox(favoriteState, setFavoriteState)}
+        />
+      </div>
+      <div>
+        <div className='flex justify-between w-full'>
+          <h2 className='text-lg'>{title}</h2>
+          <Checkbox
+            targetState={readState}
+            buttonIcon={CheckIcon}
+            handleCheckbox={handleCheckbox(readState, setReadState)}
+          />
+        </div>
+        <p className='my-3'>{description}</p>
+        <div className='flex justify-between w-full'>
+          <p>{parsedPubDate}</p>
+          <p>{origin}</p>
+        </div>
+      </div>
+      <style jsx>{`
+        p {
+          font-size: 0.875rem;
+          line-height: 1.25rem;
+        }
+      `}</style>
+    </section>
+  );
+}

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -63,7 +63,7 @@ export default function Card({ cardData }: CardProps) {
 
   return (
     <section
-      className={`flex rounded-md shadow-lg px-6 py-4 bg-neutral-100 text-black cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200 transition-all hover:scale-105 ${returnReadStyle(isRead, readState)}`}
+      className={`flex rounded-md shadow-lg mb-8 px-6 py-4 bg-neutral-100 text-neutral-700 cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200 transition-all hover:scale-105 ${returnReadStyle(isRead, readState)}`}
       onClick={handleCard}
     >
       <div className='mr-4 py-1'>
@@ -73,7 +73,7 @@ export default function Card({ cardData }: CardProps) {
           handleCheckbox={handleFavorite(favoriteState, setFavoriteState)}
         />
       </div>
-      <div>
+      <div className='w-full'>
         <div className='flex justify-between w-full'>
           <h2 className='text-lg'>{title}</h2>
           <Checkbox

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import axios from 'axios';
 import { AiFillStar as FavoriteIcon, AiFillRead as CheckIcon } from 'react-icons/ai';
 import { FeedsObjectType } from 'types/global';
 import useDerivedStateFromProps from './hooks/useDerivedStateFromProps';
@@ -11,15 +12,20 @@ type CardProps = {
 type CallbackType = (value: any) => void;
 
 export default function Card({ cardData }: CardProps) {
-  const { id, title, description, link, pubDate, origin, isRead, isFavorite } = cardData;
+  const { title, description, link, pubDate, origin, isRead, isFavorite } = cardData;
   const parsedPubDate = new Date(pubDate as string).toDateString();
   const [readState, setReadState] = useDerivedStateFromProps<boolean>(isRead);
   const [favoriteState, setFavoriteState] = useDerivedStateFromProps<boolean>(isFavorite);
 
   function handleCard(event: React.MouseEvent) {
     if (!(event.target instanceof SVGElement)) {
+      const newData = {
+        ...cardData,
+        isRead: true,
+        isFavorite: favoriteState,
+      }
+      axios.patch('/feed', newData);
       if (link) window.location.assign(link);
-      setReadState(true);
     }
   }
 
@@ -29,9 +35,19 @@ export default function Card({ cardData }: CardProps) {
     };
   }
 
+  const returnReadStyle = (booleanA: boolean, booleanB: boolean) => {
+    if (booleanA) {
+      if (booleanB) return 'brightness-75 dark:opacity-50';
+      else return 'brightness-100 dark:opacity-100';
+    } else {
+      if (booleanB) return 'brightness-75 dark:opacity-50';
+      else return 'brightness-100 dark:opacity-100';
+    }
+  };
+
   return (
     <section
-      className={`flex rounded-md shadow-lg px-6 py-4 bg-neutral-100 text-black cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200 transition-all hover:scale-105 ${(isRead || readState) ? 'brightness-75 dark:opacity-50' : 'brightness-100 dark:opacity-100'}`}
+      className={`flex rounded-md shadow-lg px-6 py-4 bg-neutral-100 text-black cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200 transition-all hover:scale-105 ${returnReadStyle(isRead, readState)}`}
       onClick={handleCard}
     >
       <div className='mr-4 py-1'>

--- a/components/card/index.tsx
+++ b/components/card/index.tsx
@@ -31,7 +31,7 @@ export default function Card({ cardData }: CardProps) {
 
   return (
     <section
-      className='flex rounded-md shadow-lg px-6 py-4 bg-neutral-100 text-black cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200'
+      className={`flex rounded-md shadow-lg px-6 py-4 bg-neutral-100 text-black cursor-pointer select-none dark:shadow-zinc-600 dark:bg-neutral-700 dark:text-neutral-200 transition-all hover:scale-105 ${(isRead || readState) ? 'brightness-75 dark:opacity-50' : 'brightness-100 dark:opacity-100'}`}
       onClick={handleCard}
     >
       <div className='mr-4 py-1'>

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -19,13 +19,13 @@ export default function Search() {
         name='searchInput'
         type='text'
         placeholder='검색어를 입력해주세요'
-        className='w-[calc(100%-6rem)] h-full p-4 dark:focus:outline-sky-600'
+        className='w-[calc(100%-6rem)] h-full p-4 text-neutral-700 dark:focus:outline-sky-600 dark:text-neutral-200'
       />
       <input
         name='submit'
         type='submit'
         value='검색'
-        className='w-24 h-full rounded-r-md bg-sky-400 text-white dark:bg-sky-800 dark:text-gray-300 cursor-pointer'
+        className='w-24 h-full rounded-r-md bg-sky-400 text-neutral-100 dark:bg-sky-800 dark:text-gray-300 cursor-pointer'
       />
     </form>
   );

--- a/controllers/helpers.ts
+++ b/controllers/helpers.ts
@@ -5,11 +5,16 @@ interface ConcatGenericType {
   originName?: string | null;
 }
 
-export const checkIfPOSTRequestValid = (feedsObjectArray: FeedsObjectType[]) => {
-  return feedsObjectArray.filter((feedsObject: FeedsObjectType) => Object.keys(feedsObject).length < 8).length;
+export const returnMutationRequestKeys = (feedsObjectArray: FeedsObjectType[]) => {
+  return feedsObjectArray.filter(
+    (feedsObject: FeedsObjectType) => Object.keys(feedsObject).length < 8
+  ).length;
 };
 
-export const concatOverlayWithNewData = <T extends ConcatGenericType>(originalContentsArray: T[], newArray: T[]) => {
+export const concatOverlayWithNewData = <T extends ConcatGenericType>(
+  originalContentsArray: T[],
+  newArray: T[]
+) => {
   if (originalContentsArray.length === 0) {
     return originalContentsArray.concat(newArray);
   } else {
@@ -17,9 +22,29 @@ export const concatOverlayWithNewData = <T extends ConcatGenericType>(originalCo
       if ('title' in newData) {
         return !originalContentsArray.some((storedData: T) => storedData.title === newData.title);
       } else if ('originName' in newData) {
-        return !originalContentsArray.some((storedData: T) => storedData.originName === newData.originName);
+        return !originalContentsArray.some(
+          (storedData: T) => storedData.originName === newData.originName
+        );
       }
     });
     return originalContentsArray.concat(overlayFiltered);
   }
+};
+
+export const concatNewDataByReplaceOldElement = <T extends { id: number }>(
+  oldArray: T[],
+  newData: T
+) => {
+  const oldElementHavingSameIdWithNewData = oldArray.find(
+    (oldElement: T) => oldElement.id === newData.id
+  );
+  const indexOfOldElementHavingSameId = oldArray.indexOf(oldElementHavingSameIdWithNewData as T);
+  const arrayIncludesSameId = oldArray.slice(0, indexOfOldElementHavingSameId + 1);
+  const arrayWithoutSameId = oldArray.slice(indexOfOldElementHavingSameId + 1);
+  const arrayWithNewData =
+    arrayIncludesSameId.length === 1
+      ? [newData]
+      : arrayIncludesSameId.slice(0, arrayIncludesSameId.length - 1).concat([newData]);
+
+  return arrayWithNewData.concat(arrayWithoutSameId);
 };

--- a/controllers/index.ts
+++ b/controllers/index.ts
@@ -1,10 +1,14 @@
 import { NextApiRequest } from 'next';
 import { FeedsObjectType, FeedsSourceType } from 'types/global';
-import { checkIfPOSTRequestValid, concatOverlayWithNewData } from './helpers';
+import {
+  returnMutationRequestKeys,
+  concatOverlayWithNewData,
+  concatNewDataByReplaceOldElement,
+} from './helpers';
 
 export const handlePOSTRequest = (request: NextApiRequest, fileContents: string) => {
   const { feedsObjectArray, feedsSourceArray } = request.body;
-  const numberOfKeysLessThanEight = checkIfPOSTRequestValid(feedsObjectArray);
+  const numberOfKeysLessThanEight = returnMutationRequestKeys(feedsObjectArray);
   if (numberOfKeysLessThanEight === 0) {
     const { feeds, origins } = JSON.parse(fileContents);
     const newFeedContents = concatOverlayWithNewData<FeedsObjectType>(feeds, feedsObjectArray);
@@ -12,6 +16,21 @@ export const handlePOSTRequest = (request: NextApiRequest, fileContents: string)
     return {
       feeds: newFeedContents,
       origins: newOrigins,
+    };
+  } else {
+    return false;
+  }
+};
+
+export const handlePATCHRequest = (request: NextApiRequest, fileContents: string) => {
+  const newData = request.body;
+  const numberOfKeysLessThanEight = returnMutationRequestKeys([newData]);
+  if (numberOfKeysLessThanEight === 0) {
+    const { feeds, origins } = JSON.parse(fileContents);
+    const feedsArrayWithNewData = concatNewDataByReplaceOldElement(feeds, newData);
+    return {
+      feeds: feedsArrayWithNewData,
+      origins,
     };
   } else {
     return false;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "axios": "^0.27.2",
     "next": "12.2.5",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-icons": "^4.4.0",
+    "react-query": "^3.39.2"
   },
   "devDependencies": {
     "@types/node": "18.7.15",

--- a/pages/api/staticdata.ts
+++ b/pages/api/staticdata.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { handlePOSTRequest } from 'controllers';
+import { handlePOSTRequest, handlePATCHRequest } from 'controllers';
 
 export default async function handler(request: NextApiRequest, response: NextApiResponse) {
   const jsonDirectory = path.join(process.cwd(), 'model');
@@ -10,6 +10,14 @@ export default async function handler(request: NextApiRequest, response: NextApi
     response.status(200).json(fileContents);
   } else if (request.method === 'POST') {
     const result = handlePOSTRequest(request, fileContents);
+    if (result) {
+      fs.writeFile(`${jsonDirectory}/database.json`, JSON.stringify(result));
+      response.status(200).json('success');
+    } else {
+      response.status(416).json('Request failed: number of request properties is not satisfied.');
+    }
+  } else if (request.method === 'PATCH') {
+    const result = handlePATCHRequest(request, fileContents);
     if (result) {
       fs.writeFile(`${jsonDirectory}/database.json`, JSON.stringify(result));
       response.status(200).json('success');

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Search from 'components/search';
 import { HttpRequest } from 'api';
 import useSaveRSS from 'hooks/useSaveRSS';
+import Card from 'components/card';
 
 interface IndexProps {
   rssResponse: string;
@@ -10,11 +11,15 @@ interface IndexProps {
 
 export default function Index({ rssResponse, feeds }: IndexProps) {
   useSaveRSS(rssResponse, feeds);
+  const dummy = JSON.parse(feeds).feeds[0];
 
   return (
-    <article className='flex-center w-full h-full bg-neutral-100 dark:bg-neutral-800 dark:text-white'>
-      <section className='flex-center w-1/2 h-full'>
+    <article className='flex-center flex-col w-full h-full bg-neutral-100 dark:bg-neutral-800 dark:text-white'>
+      <section className='flex-center w-1/2 h-[30%]'>
         <Search />
+      </section>
+      <section className='flex-center w-1/2 h-[70%]'>
+        <Card cardData={dummy} />
       </section>
     </article>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import Search from 'components/search';
 import { HttpRequest } from 'api';
 import useSaveRSS from 'hooks/useSaveRSS';
 import Card from 'components/card';
+import { FeedsObjectType } from 'types/global';
 
 interface IndexProps {
   rssResponse: string;
@@ -11,16 +12,16 @@ interface IndexProps {
 
 export default function Index({ rssResponse, feeds }: IndexProps) {
   useSaveRSS(rssResponse, feeds);
-  const dummy = JSON.parse(feeds).feeds[0];
+  const feedsToDisplay = JSON.parse(feeds).feeds.map((feed: FeedsObjectType) => (
+    <Card cardData={feed} key={feed.id} />
+  ));
 
   return (
-    <article className='flex-center flex-col w-full h-full bg-neutral-100 dark:bg-neutral-800 dark:text-white'>
-      <section className='flex-center w-1/2 h-[30%]'>
+    <article className='flex-center flex-col w-full h-max min-h-full bg-neutral-100 dark:bg-neutral-800 dark:text-neutral-200 overflow-auto'>
+      <section className='flex-center w-1/2 h-1/3 my-[10%]'>
         <Search />
       </section>
-      <section className='flex-center w-1/2 h-[70%]'>
-        <Card cardData={dummy} />
-      </section>
+      <section className='w-1/2 h-max'>{feedsToDisplay}</section>
     </article>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@eslint/eslintrc@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.1.tgz#de0807bfeffc37b964a7d0400e0c348ce5a2543d"
@@ -404,6 +411,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
@@ -423,6 +435,20 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browserslist@^4.21.3:
   version "4.21.3"
@@ -581,6 +607,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+detect-node@^2.0.4, detect-node@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 detective@^5.2.1:
   version "5.2.1"
@@ -1293,6 +1324,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -1381,6 +1417,14 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -1393,6 +1437,11 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0:
   version "1.52.0"
@@ -1432,6 +1481,13 @@ ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -1548,6 +1604,11 @@ object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 once@^1.3.0:
   version "1.4.0"
@@ -1728,10 +1789,24 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-query@^3.39.2:
+  version "3.39.2"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.2.tgz#9224140f0296f01e9664b78ed6e4f69a0cc9216f"
+  integrity sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
 
 react@18.2.0:
   version "18.2.0"
@@ -1773,6 +1848,11 @@ regexpp@^3.2.0:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -1801,7 +1881,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -2024,6 +2104,14 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 update-browserslist-db@^1.0.5:
   version "1.0.7"


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- RSS 피드 표시용 카드 컴포넌트 제작
- PATCH 핸들러 구현
- 테크 블로그 글로 이동하거나 즐겨찾기, 읽음 표시 버튼을 누르면 각각 DB에 상태가 반영되는 로직 구현
- 전체 피드 메인 페이지에 표시

## 📸 스크린샷
![스크린샷 2022-09-12 오전 1 14 47](https://user-images.githubusercontent.com/20578093/189538054-4b09fe95-46fa-4f4d-bb16-7ae77d5ea260.png)

## 🧐 논의할 점
- 새 RSS 피드 구독 기능 구현
- 수동 및 일정 시간마다 새로고침 구현
- 페이지네이션 구현 + 정해진 개수만 표시하도록 구현
- json -> DB 마이그레이션 필요
