### PR TITLE
#36 fix: 변경된 api 스펙 반영을 통해 갱신된 피드를 받아오지 못하는 문제 수정

### DIFF
--- a/pages/api/feeds/new.ts
+++ b/pages/api/feeds/new.ts
@@ -38,7 +38,7 @@ export default async function feedsHandler(
                 getPaginationIndexes("1", "10");
             const { data } = await getDataFrom(`/sources?userId=${userId}`);
 
-            const { sources }: FileContentsInterface = JSON.parse(data);
+            const sources: SourceData[] = JSON.parse(data);
             const urlsToGetFeeds = sources
                 ? sources.map((sourceData: SourceData) => sourceData.url)
                 : [];


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- 변경된 api 스펙을 반영하지 않아 새 피드를 받아오지 못하던 문제 수정
    - 기존: 피드 출처 목록을 서버에서 받아온 후 response 객체의 프로퍼티로서 추출
    - 수정: 피드 출처 목록을 반환하는 함수가 피드 출처 목록을 반환하도록 수정

## 📸 스크린샷

## 🧐 논의할 점
