### PR TITLE
Feature/20240208-visualize-feeds-renew: 클라이언트에 피드 갱신 상태 메세지 추가

### DIFF
--- a/app/api/feeds/new/route.ts
+++ b/app/api/feeds/new/route.ts
@@ -95,6 +95,7 @@ export async function GET(req: NextRequest) {
             );
         }
     } catch (error) {
+        console.error(error);
         return NextResponse.json(
             { error: "err_renew_req_failed", status: 400 },
             { status: 400 }
@@ -121,6 +122,7 @@ export async function POST(req: NextRequest) {
             );
         }
     } catch (error) {
+        console.error(error);
         return NextResponse.json(
             { error: "err_renew_req_failed", status: 400 },
             { status: 400 }

--- a/app/api/feeds/new/route.ts
+++ b/app/api/feeds/new/route.ts
@@ -71,22 +71,34 @@ export async function GET(req: NextRequest) {
             );
 
             if (storedFeeds.length === 0 || differentiateResult.length > 0) {
-                fetch(
-                    `${process.env.NEXT_PUBLIC_REQUEST_API}/feeds/new?userId=${rawId}`,
-                    {
-                        body: JSON.stringify(updatedFeedSets),
-                        method: "POST",
-                    }
-                );
-                return NextResponse.json(responseBody);
+                const postResult = await (
+                    await fetch(
+                        `${process.env.NEXT_PUBLIC_REQUEST_API}/feeds/new?userId=${rawId}`,
+                        {
+                            body: JSON.stringify(updatedFeedSets),
+                            method: "POST",
+                        }
+                    )
+                ).json();
+                if (postResult === "success") {
+                    return NextResponse.json(responseBody);
+                } else {
+                    return NextResponse.json(postResult);
+                }
             } else {
-                return NextResponse.json("no new feeds available");
+                return NextResponse.json({ result: "no new feeds available" });
             }
         } else {
-            return NextResponse.error();
+            return NextResponse.json(
+                { error: "err_no_source", status: 400 },
+                { status: 400 }
+            );
         }
     } catch (error) {
-        return NextResponse.error();
+        return NextResponse.json(
+            { error: "err_renew_req_failed", status: 400 },
+            { status: 400 }
+        );
     }
 }
 
@@ -103,10 +115,16 @@ export async function POST(req: NextRequest) {
         if (updateResult?.acknowledged) {
             return NextResponse.json("success");
         } else {
-            return NextResponse.error();
+            return NextResponse.json(
+                { error: "update failed", status: 400 },
+                { status: 400 }
+            );
         }
     } catch (error) {
-        return NextResponse.error();
+        return NextResponse.json(
+            { error: "err_renew_req_failed", status: 400 },
+            { status: 400 }
+        );
     }
 }
 

--- a/app/api/feeds/route.ts
+++ b/app/api/feeds/route.ts
@@ -109,7 +109,11 @@ export async function GET(req: NextRequest) {
 
         return NextResponse.json(JSON.stringify(responseBody));
     } catch (error) {
-        return NextResponse.error();
+        console.error(error);
+        return NextResponse.json(
+            { error: "err_feeds_req_failed", status: 400 },
+            { status: 400 }
+        );
     }
 }
 

--- a/app/main/index.tsx
+++ b/app/main/index.tsx
@@ -47,12 +47,20 @@ interface FeedsCache {
     [key: number]: ParsedFeedsDataType[];
 }
 
+export const STATE_MESSAGE_STRINGS = {
+    start: "피드 갱신을 시작합니다.",
+    proceed: "피드 갱신을 진행중입니다.",
+    no_change: "새로운 피드가 없습니다.",
+    added: (count: number) => `${count}개의 새로운 피드가 추가되었습니다.`,
+    end: "피드 갱신이 완료되었습니다.",
+} as const;
+
 export default function MainPage({
     feeds,
     sources,
     userId,
     isLocal,
-}: MainProps) {
+}: Readonly<MainProps>) {
     const { getDataFrom } = new RequestControllers();
     const [currentSort, setCurrentSort] = useState(0);
     const [isFilterFavorite, setIsFilterFavorite] = useState<boolean>(false);
@@ -62,6 +70,9 @@ export default function MainPage({
     const [isMobileLayout, setIsMobileLayout] = useState<boolean>(false);
     const [currentPage, setCurrentPage] = useState<number>(1);
     const [formerFeedsList, setFormerFeedsList] = useState<FeedsCache>({});
+    const [renewState, setRenewState] = useState<string>(
+        STATE_MESSAGE_STRINGS.start
+    );
     const [sourceDisplayState, setSourceDisplayState] = useFilters(
         sources,
         true
@@ -70,11 +81,15 @@ export default function MainPage({
         JSON.stringify(Object.values(SEARCH_OPTIONS)),
         ""
     );
-    const newFeedsRequestResult = useQuery({
+    const {
+        data: newFeedsRequestResult,
+        isFetching: isNewFetching,
+        isFetched: isNewFetched,
+    } = useQuery({
         queryKey: [`/feeds/new?userId=${userId}`],
         queryFn: () =>
             isLocal ? null : getDataFrom<string>(`/feeds/new?userId=${userId}`),
-    })?.data;
+    });
     const {
         data: storedFeed,
         refetch: refetchStoredFeeds,
@@ -104,7 +119,7 @@ export default function MainPage({
                       })}`
                   ),
         getNextPageParam: (lastPage: string) => {
-            if (lastPage === '' || !JSON.parse(lastPage).data) return 1;
+            if (lastPage === "" || !JSON.parse(lastPage).data) return 1;
             const totalCount = JSON.parse(lastPage)?.count;
             if (currentPage >= Math.ceil(totalCount / 10)) return;
             return currentPage + 1;
@@ -223,8 +238,17 @@ export default function MainPage({
             typeof newFeedsRequestResult !== "string"
         ) {
             const { count, data } = newFeedsRequestResult;
-            if (count !== totalCount) setTotalCount(count);
+            if (count !== totalCount) {
+                setTotalCount(count);
+            }
+            if (count !== 0) {
+                setRenewState(STATE_MESSAGE_STRINGS.added(count));
+            } else {
+                setRenewState(STATE_MESSAGE_STRINGS.end);
+            }
             updateFormerFeedsList(data);
+        } else {
+            setRenewState(STATE_MESSAGE_STRINGS.no_change);
         }
     }, [newFeedsRequestResult]);
 
@@ -296,6 +320,12 @@ export default function MainPage({
         }
     }, [observerElement, hasNextPage]);
 
+    useEffect(() => {
+        if (isNewFetching) {
+            setRenewState(STATE_MESSAGE_STRINGS.proceed);
+        }
+    }, [isNewFetched, isNewFetching]);
+
     return (
         <MainView
             feedsFromServer={feedsFromServer}
@@ -312,6 +342,7 @@ export default function MainPage({
             refetchStoredFeeds={refetchStoredFeeds}
             setSearchTexts={setSearchTexts}
             filterFavorites={filterFavorites}
+            renewState={renewState}
         />
     );
 }

--- a/components/common/Spinner.tsx
+++ b/components/common/Spinner.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import type { SVGProps } from "react";
+
+export function SvgSpinners90RingWithBg(props: SVGProps<SVGSVGElement>) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="1rem"
+            height="1rem"
+            viewBox="0 0 24 24"
+            {...props}
+        >
+            <path
+                // fill="currentColor"
+                d="M12,1A11,11,0,1,0,23,12,11,11,0,0,0,12,1Zm0,19a8,8,0,1,1,8-8A8,8,0,0,1,12,20Z"
+                opacity={0.25}
+            ></path>
+            <path
+                fill="currentColor"
+                d="M10.14,1.16a11,11,0,0,0-9,8.92A1.59,1.59,0,0,0,2.46,12,1.52,1.52,0,0,0,4.11,10.7a8,8,0,0,1,6.66-6.61A1.42,1.42,0,0,0,12,2.69h0A1.57,1.57,0,0,0,10.14,1.16Z"
+            >
+                <animateTransform
+                    attributeName="transform"
+                    dur="0.75s"
+                    repeatCount="indefinite"
+                    type="rotate"
+                    values="0 12 12;360 12 12"
+                ></animateTransform>
+            </path>
+        </svg>
+    );
+}

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -3,7 +3,7 @@ import { ChangeEvent, FormEvent, memo, useEffect, useState } from "react";
 import { SEARCH_ADDRESS_BY_ENGINE } from "./utils/constants";
 
 import { extractFormValues, openSearchResult } from "./utils/helpers";
-import useHandleInputFill from './hooks/useHandleInputFill';
+import useHandleInputFill from "./hooks/useHandleInputFill";
 
 import SelectBox from "../common/SelectBox";
 
@@ -28,18 +28,18 @@ export default memo(function Search() {
 
     return (
         <form
-            className="relative flex-center w-full h-12 shadow-lg dark:shadow-zinc-600"
+            className="relative flex-center w-full h-12 rounded-md shadow-lg dark:shadow-zinc-600"
             onSubmit={handleSubmit}
         >
             <SelectBox
                 optionValues={searchEngines}
-                customStyles="rounded-l-md"
+                customStyles="w-24 rounded-l-md"
             />
             <input
                 name="searchInput"
                 type="text"
                 placeholder="검색어를 입력해주세요"
-                className="w-[calc(100%-12.125rem)] h-full p-4 text-neutral-700 dark:focus:outline-sky-600 dark:text-neutral-200"
+                className="w-[calc(100%-12rem)] h-full p-4 text-neutral-700 dark:focus:outline-sky-600 dark:text-neutral-200"
                 value={inputValue}
                 onChange={handleChange}
             />
@@ -60,4 +60,4 @@ export default memo(function Search() {
             />
         </form>
     );
-})
+});


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- 클라이언트에서 피드 갱신이 진행중일 때 진행 상태를 사용자가 알 수 있도록 아래 스크린샷과 같이 관련 메세지가 표시되는 기능을 구현했습니다.
- 상세 메세지는 아래와 같습니다.
    - `피드 갱신을 시작합니다.`: 초기 상태이며, 피드 갱신 절차가 시작되는 시점에 표시되는 문구입니다.
    - `피드 갱신을 진행중입니다.`: `GET:/feeds/new`로 request가 발생해 구독 출처로부터 갱신된 피드가 있는지 확인하는 절차가 진행중일 때 표시되는 문구입니다.
    - `새로운 피드가 없습니다.`: 모든 구독 출처에서 갱신된 피드가 없을 경우 표시되는 문구입니다.
    - `n개의 새로운 피드가 추가되었습니다.`: 새로운 구독 출처가 추가되거나 기존 구독 출처로부터 새로운 피드가 추가됐을 때 표시되는 문구입니다.
    - `피드 갱신이 완료되었습니다.`: 피드 갱신 절차가 완료됐을 때 표시되는 문구입니다.(현재 미사용)
    - `구독 중인 사이트가 존재하지 않습니다.`: 예외 처리 조건을 벗어나 구독 중인 사이트가 존재하지 않음에도 갱신 절차가 발생했을 때 표시되는 문구입니다.
    - `피드 갱신 요청이 실패했습니다.`: 어떠한 원인으로 인해 피드 갱신 요청이 실패한 경우 표시되는 문구입니다.
    - `오류가 발생했습니다.`: 개발자가 의도하지 않은 오류가 발생했을 때 표시되는 문구입니다.(현재 미사용)
    ※ 미사용 메세지의 경우 추후 업데이트를 통해 사용하도록 수정될 수 있습니다.

## 📸 스크린샷
![스크린샷 2024-02-14 오후 11 14 49](https://github.com/godcl1623/start-page/assets/20578093/013302a5-c876-4b1b-b2d7-c4cc608322f9)

## 🧐 논의할 점
- 컴포넌트 파일에서 관리하는 데이터가 많아짐에 따라 이러한 관리 구조를 개선하기 위한 디렉터리 구조 수정이 필요해 보입니다.
