### PR TITLE
Feature/20240226-add-theme-button: 다크모드 토글기능 추가

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -49,7 +49,7 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:18.2.0"],\
           ["react-icons", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:4.12.0"],\
           ["sharp", "npm:0.33.2"],\
-          ["tailwindcss", "npm:3.3.6"],\
+          ["tailwindcss", "npm:3.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
@@ -6234,10 +6234,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:15.1.0", {\
-        "packageLocation": "./.yarn/__virtual__/postcss-import-virtual-7f37d1ffd4/0/cache/postcss-import-npm-15.1.0-8b9e86f900-33c91b7e6b.zip/node_modules/postcss-import/",\
+      ["virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:15.1.0", {\
+        "packageLocation": "./.yarn/__virtual__/postcss-import-virtual-1f4f253a7b/0/cache/postcss-import-npm-15.1.0-8b9e86f900-33c91b7e6b.zip/node_modules/postcss-import/",\
         "packageDependencies": [\
-          ["postcss-import", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:15.1.0"],\
+          ["postcss-import", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:15.1.0"],\
           ["@types/postcss", null],\
           ["postcss", "npm:8.4.32"],\
           ["postcss-value-parser", "npm:4.2.0"],\
@@ -6259,10 +6259,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:4.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/postcss-js-virtual-52af3de804/0/cache/postcss-js-npm-4.0.1-2c4ee70bf3-ef2cfe8554.zip/node_modules/postcss-js/",\
+      ["virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:4.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/postcss-js-virtual-9748b27a44/0/cache/postcss-js-npm-4.0.1-2c4ee70bf3-ef2cfe8554.zip/node_modules/postcss-js/",\
         "packageDependencies": [\
-          ["postcss-js", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:4.0.1"],\
+          ["postcss-js", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:4.0.1"],\
           ["@types/postcss", null],\
           ["camelcase-css", "npm:2.0.1"],\
           ["postcss", "npm:8.4.32"]\
@@ -6282,10 +6282,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:4.0.2", {\
-        "packageLocation": "./.yarn/__virtual__/postcss-load-config-virtual-ccedc0fd0a/0/cache/postcss-load-config-npm-4.0.2-319bcff9ca-e2c2ed9b79.zip/node_modules/postcss-load-config/",\
+      ["virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:4.0.2", {\
+        "packageLocation": "./.yarn/__virtual__/postcss-load-config-virtual-8ffc83a6c5/0/cache/postcss-load-config-npm-4.0.2-319bcff9ca-e2c2ed9b79.zip/node_modules/postcss-load-config/",\
         "packageDependencies": [\
-          ["postcss-load-config", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:4.0.2"],\
+          ["postcss-load-config", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:4.0.2"],\
           ["@types/postcss", null],\
           ["@types/ts-node", null],\
           ["lilconfig", "npm:3.0.0"],\
@@ -6310,10 +6310,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:6.0.1", {\
-        "packageLocation": "./.yarn/__virtual__/postcss-nested-virtual-d3f1d964c7/0/cache/postcss-nested-npm-6.0.1-5cdc427fe8-02aaac682f.zip/node_modules/postcss-nested/",\
+      ["virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:6.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/postcss-nested-virtual-03a54ddab3/0/cache/postcss-nested-npm-6.0.1-5cdc427fe8-02aaac682f.zip/node_modules/postcss-nested/",\
         "packageDependencies": [\
-          ["postcss-nested", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:6.0.1"],\
+          ["postcss-nested", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:6.0.1"],\
           ["@types/postcss", null],\
           ["postcss", "npm:8.4.32"],\
           ["postcss-selector-parser", "npm:6.0.13"]\
@@ -7116,7 +7116,7 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:18.2.0"],\
           ["react-icons", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:4.12.0"],\
           ["sharp", "npm:0.33.2"],\
-          ["tailwindcss", "npm:3.3.6"],\
+          ["tailwindcss", "npm:3.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
         "linkType": "SOFT"\
@@ -7340,10 +7340,10 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["tailwindcss", [\
-      ["npm:3.3.6", {\
-        "packageLocation": "./.yarn/cache/tailwindcss-npm-3.3.6-473baaff8e-7cca9ce2d4.zip/node_modules/tailwindcss/",\
+      ["npm:3.4.1", {\
+        "packageLocation": "./.yarn/cache/tailwindcss-npm-3.4.1-3903e2abcc-bf460657c6.zip/node_modules/tailwindcss/",\
         "packageDependencies": [\
-          ["tailwindcss", "npm:3.3.6"],\
+          ["tailwindcss", "npm:3.4.1"],\
           ["@alloc/quick-lru", "npm:5.2.0"],\
           ["arg", "npm:5.0.2"],\
           ["chokidar", "npm:3.5.3"],\
@@ -7359,10 +7359,10 @@ const RAW_RUNTIME_STATE =
           ["object-hash", "npm:3.0.0"],\
           ["picocolors", "npm:1.0.0"],\
           ["postcss", "npm:8.4.32"],\
-          ["postcss-import", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:15.1.0"],\
-          ["postcss-js", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:4.0.1"],\
-          ["postcss-load-config", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:4.0.2"],\
-          ["postcss-nested", "virtual:473baaff8efa0b7d96756cf249f9cf64d200c7a802e44c9437de85b9f589b64e642253ebf057ce09873a9aa4f0295d3bcbfb6a9aba5b0a4ab476e5eb5ee8f860#npm:6.0.1"],\
+          ["postcss-import", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:15.1.0"],\
+          ["postcss-js", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:4.0.1"],\
+          ["postcss-load-config", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:4.0.2"],\
+          ["postcss-nested", "virtual:3903e2abcca6da181c68e3e2b020ce8f100d606c384b27bb480d49951a24008cb45e54ac92bc5acb3f9572c7f339e46fe691a8e40f22e16c18dac03b8a3a63fc#npm:6.0.1"],\
           ["postcss-selector-parser", "npm:6.0.13"],\
           ["resolve", "patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"],\
           ["sucrase", "npm:3.34.0"]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -33,7 +33,6 @@ const RAW_RUNTIME_STATE =
           ["@types/node", "npm:20.10.4"],\
           ["@types/react", "npm:18.2.45"],\
           ["@types/react-dom", "npm:18.2.17"],\
-          ["@types/suncalc", "npm:1.9.2"],\
           ["@yarnpkg/sdks", "npm:3.1.0"],\
           ["autoprefixer", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:10.4.16"],\
           ["cookies-next", "npm:4.1.0"],\
@@ -50,7 +49,6 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:18.2.0"],\
           ["react-icons", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:4.12.0"],\
           ["sharp", "npm:0.33.2"],\
-          ["suncalc", "npm:1.9.0"],\
           ["tailwindcss", "npm:3.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
@@ -1815,15 +1813,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@types-semver-npm-7.3.13-56212b60da-0064efd7a0.zip/node_modules/@types/semver/",\
         "packageDependencies": [\
           ["@types/semver", "npm:7.3.13"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["@types/suncalc", [\
-      ["npm:1.9.2", {\
-        "packageLocation": "./.yarn/cache/@types-suncalc-npm-1.9.2-1650f3998d-3a2d3b48b5.zip/node_modules/@types/suncalc/",\
-        "packageDependencies": [\
-          ["@types/suncalc", "npm:1.9.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7111,7 +7100,6 @@ const RAW_RUNTIME_STATE =
           ["@types/node", "npm:20.10.4"],\
           ["@types/react", "npm:18.2.45"],\
           ["@types/react-dom", "npm:18.2.17"],\
-          ["@types/suncalc", "npm:1.9.2"],\
           ["@yarnpkg/sdks", "npm:3.1.0"],\
           ["autoprefixer", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:10.4.16"],\
           ["cookies-next", "npm:4.1.0"],\
@@ -7128,7 +7116,6 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:18.2.0"],\
           ["react-icons", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:4.12.0"],\
           ["sharp", "npm:0.33.2"],\
-          ["suncalc", "npm:1.9.0"],\
           ["tailwindcss", "npm:3.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
@@ -7320,15 +7307,6 @@ const RAW_RUNTIME_STATE =
           ["mz", "npm:2.7.0"],\
           ["pirates", "npm:4.0.6"],\
           ["ts-interface-checker", "npm:0.1.13"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["suncalc", [\
-      ["npm:1.9.0", {\
-        "packageLocation": "./.yarn/cache/suncalc-npm-1.9.0-48613f417e-ba24acf67a.zip/node_modules/suncalc/",\
-        "packageDependencies": [\
-          ["suncalc", "npm:1.9.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -33,6 +33,7 @@ const RAW_RUNTIME_STATE =
           ["@types/node", "npm:20.10.4"],\
           ["@types/react", "npm:18.2.45"],\
           ["@types/react-dom", "npm:18.2.17"],\
+          ["@types/suncalc", "npm:1.9.2"],\
           ["@yarnpkg/sdks", "npm:3.1.0"],\
           ["autoprefixer", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:10.4.16"],\
           ["cookies-next", "npm:4.1.0"],\
@@ -49,6 +50,7 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:18.2.0"],\
           ["react-icons", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:4.12.0"],\
           ["sharp", "npm:0.33.2"],\
+          ["suncalc", "npm:1.9.0"],\
           ["tailwindcss", "npm:3.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
@@ -1813,6 +1815,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/cache/@types-semver-npm-7.3.13-56212b60da-0064efd7a0.zip/node_modules/@types/semver/",\
         "packageDependencies": [\
           ["@types/semver", "npm:7.3.13"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@types/suncalc", [\
+      ["npm:1.9.2", {\
+        "packageLocation": "./.yarn/cache/@types-suncalc-npm-1.9.2-1650f3998d-3a2d3b48b5.zip/node_modules/@types/suncalc/",\
+        "packageDependencies": [\
+          ["@types/suncalc", "npm:1.9.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -7100,6 +7111,7 @@ const RAW_RUNTIME_STATE =
           ["@types/node", "npm:20.10.4"],\
           ["@types/react", "npm:18.2.45"],\
           ["@types/react-dom", "npm:18.2.17"],\
+          ["@types/suncalc", "npm:1.9.2"],\
           ["@yarnpkg/sdks", "npm:3.1.0"],\
           ["autoprefixer", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:10.4.16"],\
           ["cookies-next", "npm:4.1.0"],\
@@ -7116,6 +7128,7 @@ const RAW_RUNTIME_STATE =
           ["react-dom", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:18.2.0"],\
           ["react-icons", "virtual:ac7396aa9aa040d60303fe434d9232d7824b72cb0ee6f6df5fde945520e7a0762a5b96b4b5dd5c702112ab1f874a05844d926af559aa9745e664298f70823d4f#npm:4.12.0"],\
           ["sharp", "npm:0.33.2"],\
+          ["suncalc", "npm:1.9.0"],\
           ["tailwindcss", "npm:3.4.1"],\
           ["typescript", "patch:typescript@npm%3A5.3.3#optional!builtin<compat/typescript>::version=5.3.3&hash=e012d7"]\
         ],\
@@ -7307,6 +7320,15 @@ const RAW_RUNTIME_STATE =
           ["mz", "npm:2.7.0"],\
           ["pirates", "npm:4.0.6"],\
           ["ts-interface-checker", "npm:0.1.13"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["suncalc", [\
+      ["npm:1.9.0", {\
+        "packageLocation": "./.yarn/cache/suncalc-npm-1.9.0-48613f417e-ba24acf67a.zip/node_modules/suncalc/",\
+        "packageDependencies": [\
+          ["suncalc", "npm:1.9.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,9 @@ import { ReactNode } from "react";
 import { Metadata } from "next";
 import Providers from "./root/providers";
 import "tailwindcss/tailwind.css";
-import { getServerSession } from 'next-auth';
-import { authOptions } from './api/auth/[...nextauth]/setting';
+import { getServerSession } from "next-auth";
+import { authOptions } from "./api/auth/[...nextauth]/setting";
+import { cookies } from "next/headers";
 
 // TODO: use next-auth session on server components
 export default async function RootLayout({
@@ -12,9 +13,10 @@ export default async function RootLayout({
     readonly children: ReactNode;
 }) {
     const session = await getServerSession(authOptions);
+    const theme = cookies().get("theme");
 
     return (
-        <html lang="ko">
+        <html lang="ko" className={theme?.value === 'dark' ? 'dark' : ''}>
             <body>
                 <main>
                     <Providers session={session}>{children}</Providers>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "tailwindcss/tailwind.css";
 import { getServerSession } from "next-auth";
 import { authOptions } from "./api/auth/[...nextauth]/setting";
 import { cookies } from "next/headers";
+import { calculateSunsetSunrise } from 'common/helpers';
 
 // TODO: use next-auth session on server components
 export default async function RootLayout({
@@ -14,9 +15,11 @@ export default async function RootLayout({
 }) {
     const session = await getServerSession(authOptions);
     const theme = cookies().get("theme");
+    const { isSunset, isSunrise } = await calculateSunsetSunrise();
+    const darkmodeClass = theme?.value === 'dark' ? 'dark' : isSunset && !isSunrise ? 'dark' : '';
 
     return (
-        <html lang="ko" className={theme?.value === 'dark' ? 'dark' : ''}>
+        <html lang="ko" className={`${darkmodeClass} sunset_${isSunset} sunrise_${isSunrise}`}>
             <body>
                 <main>
                     <Providers session={session}>{children}</Providers>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@ import "tailwindcss/tailwind.css";
 import { getServerSession } from "next-auth";
 import { authOptions } from "./api/auth/[...nextauth]/setting";
 import { cookies } from "next/headers";
-import { calculateSunsetSunrise } from 'common/helpers';
 
 // TODO: use next-auth session on server components
 export default async function RootLayout({
@@ -15,11 +14,9 @@ export default async function RootLayout({
 }) {
     const session = await getServerSession(authOptions);
     const theme = cookies().get("theme");
-    const { isSunset, isSunrise } = await calculateSunsetSunrise();
-    const darkmodeClass = theme?.value === 'dark' ? 'dark' : isSunset && !isSunrise ? 'dark' : '';
 
     return (
-        <html lang="ko" className={`${darkmodeClass} sunset_${isSunset} sunrise_${isSunrise}`}>
+        <html lang="ko" className={theme?.value === 'dark' ? 'dark' : ''}>
             <body>
                 <main>
                     <Providers session={session}>{children}</Providers>

--- a/app/main/LoginInfoArea/LoginHandleButton.tsx
+++ b/app/main/LoginInfoArea/LoginHandleButton.tsx
@@ -10,7 +10,7 @@ export default function LoginHandleButton({
     isUserSignedIn,
     handleAuthenticationModal,
 }: Props) {
-    const commonStyle = "w-24 font-bold";
+    const commonStyle = "w-24 font-bold text-sm";
     const loginStyle =
         "bg-sky-400 text-neutral-100 dark:bg-sky-600 dark:text-gray-300";
     const logoutStyle = "bg-red-400 text-neutral-100 dark:bg-red-700";

--- a/app/main/LoginInfoArea/UserInfo.tsx
+++ b/app/main/LoginInfoArea/UserInfo.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from "react";
 
 interface Props {
-    userEmail: string | undefined;
+    userEmail: string | null | undefined;
     handleDataHandler?: () => void;
 }
 
@@ -17,7 +17,7 @@ export default forwardRef<HTMLButtonElement, Props>(function UserInfo(
                 if (handleDataHandler != null) handleDataHandler();
             }}
         >
-            {userEmail != null ? userEmail : "Guest"}
+            {userEmail ?? "Guest"}
         </button>
     );
 });

--- a/app/main/LoginInfoArea/index.tsx
+++ b/app/main/LoginInfoArea/index.tsx
@@ -3,7 +3,14 @@ import UserInfo from "./UserInfo";
 import LoginHandleButton from "./LoginHandleButton";
 import { ModalKeys } from "../MainView";
 import Button from "components/common/Button";
-import { ChangeEvent, useContext, useEffect, useRef, useState } from "react";
+import {
+    ChangeEvent,
+    useContext,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    useState,
+} from "react";
 import RequestControllers from "controllers/requestControllers";
 import useOutsideClickClose from "hooks/useOutsideClickClose";
 import { useMutation } from "@tanstack/react-query";
@@ -149,17 +156,17 @@ export default function LoginInfoArea({
         const root = document.documentElement;
         if (root.classList.contains("dark")) {
             setIsDark(false);
-            root.classList.remove('dark');
-            setCookie('theme', 'light');
+            root.classList.remove("dark");
+            setCookie("theme", "light");
         } else {
             setIsDark(true);
-            root.classList.add('dark');
-            setCookie('theme', 'dark');
+            root.classList.add("dark");
+            setCookie("theme", "dark");
         }
     };
 
-    useEffect(() => {
-        if (document.documentElement.classList.contains('dark')) {
+    useLayoutEffect(() => {
+        if (document.documentElement.classList.contains("dark")) {
             setIsDark(true);
         } else {
             setIsDark(false);
@@ -248,9 +255,21 @@ export default function LoginInfoArea({
                             데이터 이전
                         </Button>
                         <div className="flex justify-evenly w-44 px-4 py-2">
-                            <MdLightMode className="w-6 h-6 fill-yellow-400" />
-                            <button onClick={handleTheme}>test</button>
-                            <MdDarkMode className="w-6 h-6 fill-blue-400" />
+                            <MdLightMode className="w-8 h-8 fill-yellow-400" />
+                            <label className="relative w-16 h-8 mx-2 border border-transparent shadow-lg rounded-full bg-neutral-100 transition-all duration-300 cursor-pointer dark:bg-neutral-500 dark:shadow-md dark:shadow-zinc-500">
+                                <span
+                                    className={`absolute top-[3px] left-7 ${
+                                        isDark
+                                            ? "translate-x-1.5"
+                                            : "-translate-x-full"
+                                    } w-6 h-6 rounded-full shadow-md bg-gray-300 transition-all duration-300 dark:bg-neutral-700`}
+                                />
+                                <button
+                                    onClick={handleTheme}
+                                    className="hidden"
+                                ></button>
+                            </label>
+                            <MdDarkMode className="w-8 h-8 fill-blue-400" />
                         </div>
                     </div>
                 </div>

--- a/app/main/LoginInfoArea/index.tsx
+++ b/app/main/LoginInfoArea/index.tsx
@@ -3,21 +3,13 @@ import UserInfo from "./UserInfo";
 import LoginHandleButton from "./LoginHandleButton";
 import { ModalKeys } from "../MainView";
 import Button from "components/common/Button";
-import {
-    ChangeEvent,
-    useContext,
-    useEffect,
-    useLayoutEffect,
-    useRef,
-    useState,
-} from "react";
+import { ChangeEvent, useLayoutEffect, useRef, useState } from "react";
 import RequestControllers from "controllers/requestControllers";
 import useOutsideClickClose from "hooks/useOutsideClickClose";
 import { useMutation } from "@tanstack/react-query";
 import { UploadFileType } from "app/api/data/import/route";
 import { getCookie, setCookie } from "cookies-next";
 import { MdLightMode, MdDarkMode } from "react-icons/md";
-import { ThemeContext } from "app/root/ThemeContextProvider";
 
 interface Props {
     handleAuthenticationModal: (target: ModalKeys) => () => void;
@@ -27,7 +19,7 @@ interface Props {
 export default function LoginInfoArea({
     handleAuthenticationModal,
     userId,
-}: Props) {
+}: Readonly<Props>) {
     const [isDark, setIsDark] = useState(false);
     const [modalState, setModalState] = useState(false);
     const [userMenu, setUserMenu] = useState<HTMLDivElement | null>(null);
@@ -177,13 +169,7 @@ export default function LoginInfoArea({
         <section className="flex flex-col items-end gap-4 w-full md:flex-row md:gap-8 md:items-center md:justify-end">
             <UserInfo
                 ref={buttonRef}
-                userEmail={
-                    session != null &&
-                    session.user != null &&
-                    session.user.email != null
-                        ? session.user.email
-                        : undefined
-                }
+                userEmail={session?.user?.email}
                 handleDataHandler={() => setModalState(!modalState)}
             />
             {session != null ? (
@@ -209,11 +195,11 @@ export default function LoginInfoArea({
                     ref={setUserMenu}
                     className={`absolute top-0 z-10 w-full md:top-20 md:w-max`}
                     style={{
-                        right: buttonRef.current
-                            ? document.documentElement.offsetWidth > 768
+                        right:
+                            buttonRef.current &&
+                            document.documentElement.offsetWidth > 768
                                 ? buttonRef.current.offsetWidth
-                                : 0
-                            : 0,
+                                : 0,
                     }}
                 >
                     <div className="flex flex-col gap-4 justify-center items-center w-full p-4 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-700 dark:shadow-zinc-600 md:gap-6 md:w-80">

--- a/app/main/LoginInfoArea/index.tsx
+++ b/app/main/LoginInfoArea/index.tsx
@@ -3,12 +3,14 @@ import UserInfo from "./UserInfo";
 import LoginHandleButton from "./LoginHandleButton";
 import { ModalKeys } from "../MainView";
 import Button from "components/common/Button";
-import { ChangeEvent, useRef, useState } from "react";
+import { ChangeEvent, useContext, useEffect, useRef, useState } from "react";
 import RequestControllers from "controllers/requestControllers";
 import useOutsideClickClose from "hooks/useOutsideClickClose";
 import { useMutation } from "@tanstack/react-query";
 import { UploadFileType } from "app/api/data/import/route";
 import { getCookie, setCookie } from "cookies-next";
+import { MdLightMode, MdDarkMode } from "react-icons/md";
+import { ThemeContext } from "app/root/ThemeContextProvider";
 
 interface Props {
     handleAuthenticationModal: (target: ModalKeys) => () => void;
@@ -19,6 +21,7 @@ export default function LoginInfoArea({
     handleAuthenticationModal,
     userId,
 }: Props) {
+    const [isDark, setIsDark] = useState(false);
     const [modalState, setModalState] = useState(false);
     const [userMenu, setUserMenu] = useState<HTMLDivElement | null>(null);
     const buttonRef = useRef<HTMLButtonElement>(null);
@@ -142,6 +145,27 @@ export default function LoginInfoArea({
         }
     };
 
+    const handleTheme = () => {
+        const root = document.documentElement;
+        if (root.classList.contains("dark")) {
+            setIsDark(false);
+            root.classList.remove('dark');
+            setCookie('theme', 'light');
+        } else {
+            setIsDark(true);
+            root.classList.add('dark');
+            setCookie('theme', 'dark');
+        }
+    };
+
+    useEffect(() => {
+        if (document.documentElement.classList.contains('dark')) {
+            setIsDark(true);
+        } else {
+            setIsDark(false);
+        }
+    }, [isDark]);
+
     return (
         <section className="flex flex-col items-end gap-4 w-full md:flex-row md:gap-8 md:items-center md:justify-end">
             <UserInfo
@@ -185,7 +209,7 @@ export default function LoginInfoArea({
                             : 0,
                     }}
                 >
-                    <div className="flex flex-col gap-4 justify-center items-center w-full h-56 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-700 dark:shadow-zinc-600 md:gap-6 md:w-80 md:h-56">
+                    <div className="flex flex-col gap-4 justify-center items-center w-full p-4 rounded-md shadow-lg bg-neutral-100 dark:bg-neutral-700 dark:shadow-zinc-600 md:gap-6 md:w-80">
                         {document.documentElement.offsetWidth < 768 ? (
                             <button
                                 type="button"
@@ -223,6 +247,11 @@ export default function LoginInfoArea({
                         >
                             데이터 이전
                         </Button>
+                        <div className="flex justify-evenly w-44 px-4 py-2">
+                            <MdLightMode className="w-6 h-6 fill-yellow-400" />
+                            <button onClick={handleTheme}>test</button>
+                            <MdDarkMode className="w-6 h-6 fill-blue-400" />
+                        </div>
                     </div>
                 </div>
             )}

--- a/app/main/LoginInfoArea/index.tsx
+++ b/app/main/LoginInfoArea/index.tsx
@@ -163,7 +163,7 @@ export default function LoginInfoArea({
                             callbackUrl: process.env.NEXTAUTH_URL,
                         })
                     }
-                    customStyle="w-32 bg-red-400 font-bold text-base text-neutral-100  dark:bg-red-700 dark:text-gray-300"
+                    customStyle="w-32 bg-red-400 font-bold text-sm text-neutral-100  dark:bg-red-700 dark:text-gray-300"
                 >
                     Logout
                 </Button>
@@ -197,13 +197,13 @@ export default function LoginInfoArea({
                         ) : (
                             <></>
                         )}
-                        <button
+                        <Button
                             type="button"
-                            className="w-44 px-4 py-2 rounded-md bg-neutral-500 text-sm text-neutral-100 dark:text-gray-300"
-                            onClick={getTotalData}
+                            customStyle="w-44 px-4 py-2 rounded-md bg-neutral-500 text-sm text-neutral-100 dark:text-gray-300"
+                            clickHandler={getTotalData}
                         >
                             피드 / 출처 내보내기
-                        </button>
+                        </Button>
                         <label
                             ref={labelRef}
                             className="w-44 px-4 py-2 rounded-md bg-neutral-500 text-center text-sm text-neutral-100 cursor-pointer dark:text-gray-300"
@@ -216,13 +216,13 @@ export default function LoginInfoArea({
                                 onChange={uploadUserData}
                             />
                         </label>
-                        <button
+                        <Button
                             type="button"
-                            className="w-44 px-4 py-2 rounded-md bg-neutral-500 text-sm text-neutral-100 dark:text-gray-300"
-                            onClick={handleUserData}
+                            customStyle="w-44 px-4 py-2 rounded-md bg-neutral-500 text-sm text-neutral-100 dark:text-gray-300"
+                            clickHandler={handleUserData}
                         >
                             데이터 이전
-                        </button>
+                        </Button>
                     </div>
                 </div>
             )}

--- a/app/main/LoginInfoArea/index.tsx
+++ b/app/main/LoginInfoArea/index.tsx
@@ -254,20 +254,24 @@ export default function LoginInfoArea({
                         >
                             데이터 이전
                         </Button>
-                        <div className="flex justify-evenly w-44 px-4 py-2">
+                        <div className="flex justify-evenly w-44 py-2">
                             <MdLightMode className="w-8 h-8 fill-yellow-400" />
-                            <label className="relative w-16 h-8 mx-2 border border-transparent shadow-lg rounded-full bg-neutral-100 transition-all duration-300 cursor-pointer dark:bg-neutral-500 dark:shadow-md dark:shadow-zinc-500">
-                                <span
-                                    className={`absolute top-[3px] left-7 ${
+                            <label
+                                htmlFor="handleTheme"
+                                className="relative w-16 h-8 mx-2 border border-transparent shadow-lg rounded-full bg-neutral-100 transition-all duration-300 cursor-pointer dark:bg-neutral-500 dark:shadow-md dark:shadow-zinc-500"
+                            >
+                                <div
+                                    className={`absolute top-[3px] left-1 ${
                                         isDark
-                                            ? "translate-x-1.5"
-                                            : "-translate-x-full"
+                                            ? "translate-x-[calc(100%+0.4rem)]"
+                                            : "translate-x-0"
                                     } w-6 h-6 rounded-full shadow-md bg-gray-300 transition-all duration-300 dark:bg-neutral-700`}
                                 />
                                 <button
+                                    id="handleTheme"
                                     onClick={handleTheme}
                                     className="hidden"
-                                ></button>
+                                />
                             </label>
                             <MdDarkMode className="w-8 h-8 fill-blue-400" />
                         </div>

--- a/app/main/PageButton.tsx
+++ b/app/main/PageButton.tsx
@@ -1,3 +1,4 @@
+import Button from "components/common/Button";
 import { ReactNode } from "react";
 
 interface Props {
@@ -12,8 +13,12 @@ export default function PageButton({
     clickHandler,
 }: Props) {
     return (
-        <button className={`flex justify-center items-center rounded-full shadow-md w-10 h-10 bg-neutral-100 dark:shadow-zinc-500 dark:bg-neutral-700 ${customStyle}`} onClick={clickHandler}>
+        <Button
+            type="button"
+            customStyle={`flex justify-center items-center rounded-full shadow-md w-10 h-10 bg-neutral-100 dark:shadow-zinc-500 dark:bg-neutral-700 ${customStyle}`}
+            clickHandler={clickHandler}
+        >
             {children}
-        </button>
+        </Button>
     );
 }

--- a/app/main/PostHandleOptions/SubscriptionOptions.tsx
+++ b/app/main/PostHandleOptions/SubscriptionOptions.tsx
@@ -23,7 +23,7 @@ export default function SubscriptionOptions({
                 <Button
                     key={`${buttonText}_${index}`}
                     type="button"
-                    customStyle="w-full bg-neutral-500 text-neutral-100 dark:bg-neutral-500 hover:bg-neutral-400"
+                    customStyle="w-full bg-neutral-500 text-xs text-neutral-100 dark:bg-neutral-500 hover:bg-neutral-400"
                     clickHandler={clickHandler}
                 >
                     {buttonText}

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -1,4 +1,6 @@
-import { ParsedFeedsDataType } from 'app/main'; 
+import { getTimes } from 'suncalc';
+
+import { ParsedFeedsDataType } from "app/main";
 
 import {
     areEqual,
@@ -65,4 +67,27 @@ export const checkIfTodayLessThan = (
     const isTodayMoreThanDateToCheck = dateToCheck <= now;
     const isTodayLessThanExtraDay = now <= dateToCheckWithExtraDay;
     return isTodayLessThanExtraDay && isTodayMoreThanDateToCheck;
+};
+
+export const calculateSunsetSunrise = async () => {
+    try {
+        const { latitude, longitude } = (await (
+            await fetch("https://geolocation-db.com/json")
+        ).json()) ?? { latitude: 37.6564, longitude: 126.835 };
+        const current = new Date();
+        const { sunrise, sunset } = getTimes(current, latitude, longitude);
+        const currentTime = current.getTime();
+        const sunriseTime = sunrise.getTime();
+        const sunsetTime = sunset.getTime();
+        return {
+            isSunset: (currentTime - sunsetTime) >= 0,
+            isSunrise: (currentTime - sunsetTime) < 0 && (currentTime - sunriseTime) >= 0
+        };
+    } catch (error) {
+        console.error(error);
+        return {
+            isSunset: undefined,
+            isSunrise: undefined
+        }
+    }
 };

--- a/common/helpers.ts
+++ b/common/helpers.ts
@@ -1,6 +1,4 @@
-import { getTimes } from 'suncalc';
-
-import { ParsedFeedsDataType } from "app/main";
+import { ParsedFeedsDataType } from 'app/main'; 
 
 import {
     areEqual,
@@ -67,27 +65,4 @@ export const checkIfTodayLessThan = (
     const isTodayMoreThanDateToCheck = dateToCheck <= now;
     const isTodayLessThanExtraDay = now <= dateToCheckWithExtraDay;
     return isTodayLessThanExtraDay && isTodayMoreThanDateToCheck;
-};
-
-export const calculateSunsetSunrise = async () => {
-    try {
-        const { latitude, longitude } = (await (
-            await fetch("https://geolocation-db.com/json")
-        ).json()) ?? { latitude: 37.6564, longitude: 126.835 };
-        const current = new Date();
-        const { sunrise, sunset } = getTimes(current, latitude, longitude);
-        const currentTime = current.getTime();
-        const sunriseTime = sunrise.getTime();
-        const sunsetTime = sunset.getTime();
-        return {
-            isSunset: (currentTime - sunsetTime) >= 0,
-            isSunrise: (currentTime - sunsetTime) < 0 && (currentTime - sunriseTime) >= 0
-        };
-    } catch (error) {
-        console.error(error);
-        return {
-            isSunset: undefined,
-            isSunrise: undefined
-        }
-    }
 };

--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,10 +1,10 @@
-import { memo } from "react";
+import { ReactNode, memo } from "react";
 
 interface Props {
     customStyle?: string;
     type: "button" | "submit" | "reset" | undefined;
     clickHandler?: () => void;
-    children: string;
+    children: string | ReactNode;
 }
 
 export default memo(function Button({
@@ -16,7 +16,7 @@ export default memo(function Button({
     return (
         <button
             type={type}
-            className={`px-3 py-2 rounded-md shadow-md text-xs dark:shadow-zinc-600 whitespace-pre ${customStyle}`}
+            className={`px-3 py-2 rounded-md shadow-md dark:shadow-zinc-600 whitespace-pre ${customStyle}`}
             onClick={clickHandler}
         >
             {children}

--- a/components/editSearchEngines/index.tsx
+++ b/components/editSearchEngines/index.tsx
@@ -159,7 +159,7 @@ export default memo(function EditSearchEngines({
                 </table>
                 <Button
                     type="button"
-                    customStyle="w-full mt-[1px] bg-neutral-500 font-bold text-neutral-100 rounded-none dark:bg-neutral-500 dark:text-gray-300"
+                    customStyle="w-full mt-[1px] bg-neutral-500 font-bold text-sm text-neutral-100 rounded-none dark:bg-neutral-500 dark:text-gray-300"
                     clickHandler={() => setIsAppendingNewData(true)}
                 >
                     추가
@@ -168,14 +168,14 @@ export default memo(function EditSearchEngines({
             <div className="flex justify-evenly w-full">
                 <Button
                     type="button"
-                    customStyle="w-16 bg-red-400 font-bold text-neutral-100 dark:bg-red-700 dark:text-gray-300"
+                    customStyle="w-16 bg-red-400 font-bold text-xs text-neutral-100 dark:bg-red-700 dark:text-gray-300"
                     clickHandler={closeModal}
                 >
                     취소
                 </Button>
                 <Button
                     type="button"
-                    customStyle="w-16 bg-sky-400 font-bold text-neutral-100 dark:bg-sky-600 dark:text-gray-300"
+                    customStyle="w-16 bg-sky-400 font-bold text-xs text-neutral-100 dark:bg-sky-600 dark:text-gray-300"
                     clickHandler={handleSave}
                 >
                     저장

--- a/components/feeds/CancelSubscription/CancelSubscriptionView.tsx
+++ b/components/feeds/CancelSubscription/CancelSubscriptionView.tsx
@@ -29,7 +29,7 @@ export default function CancelSubscriptionView({
                         <div>{name || `blog_${index}`}</div>
                         <Button
                             type="button"
-                            customStyle="w-16 bg-red-400 font-bold text-neutral-100 dark:bg-red-700 dark:text-gray-300"
+                            customStyle="w-16 bg-red-400 font-bold text-xs text-neutral-100 dark:bg-red-700 dark:text-gray-300"
                             clickHandler={handleClick(id)}
                         >
                             삭제

--- a/components/feeds/FilterBySource/FilterBySourceView.tsx
+++ b/components/feeds/FilterBySource/FilterBySourceView.tsx
@@ -73,17 +73,17 @@ export default function FilterBySourceView({
     const buttonsData: ButtonsData = {
         취소: {
             customStyle:
-                "w-16 bg-red-400 font-bold text-neutral-100 dark:bg-red-700 dark:text-gray-300",
+                "w-16 bg-red-400 font-bold text-xs text-neutral-100 dark:bg-red-700 dark:text-gray-300",
             clickHandler: closeModal,
         },
         초기화: {
             customStyle:
-                "w-16 bg-neutral-500 font-bold text-neutral-100 dark:bg-neutral-500 dark:text-gray-300",
+                "w-16 bg-neutral-500 font-bold text-xs text-neutral-100 dark:bg-neutral-500 dark:text-gray-300",
             clickHandler: initiateDisplayFilter,
         },
         저장: {
             customStyle:
-                "w-16 bg-sky-400 font-bold text-neutral-100 dark:bg-sky-600 dark:text-gray-300",
+                "w-16 bg-sky-400 font-bold text-xs text-neutral-100 dark:bg-sky-600 dark:text-gray-300",
             clickHandler: enableDisplayFilter(saveDisplayState),
         },
     };

--- a/components/feeds/FilterByText/FilterByTextView.tsx
+++ b/components/feeds/FilterByText/FilterByTextView.tsx
@@ -46,7 +46,7 @@ const FilterByTextView = forwardRef<HTMLInputElement, Props>(
                 )}
                 <Button
                     type="submit"
-                    customStyle="w-12 rounded-r-md bg-sky-400 font-bold text-neutral-100 dark:bg-sky-600 dark:text-gray-300 shadow-none rounded-l-none"
+                    customStyle="w-12 rounded-r-md bg-sky-400 font-bold text-xs text-neutral-100 dark:bg-sky-600 dark:text-gray-300 shadow-none rounded-l-none"
                 >
                     검색
                 </Button>

--- a/components/feeds/SubscribeNew/SubscriptionForm.tsx
+++ b/components/feeds/SubscribeNew/SubscriptionForm.tsx
@@ -19,7 +19,7 @@ export default function SubscriptionForm({ handleSubmit }: Props) {
                 />
                 <Button
                     type="submit"
-                    customStyle="w-20 p-1 bg-sky-400 font-bold text-neutral-100 dark:bg-sky-600 dark:text-gray-300"
+                    customStyle="w-20 p-1 bg-sky-400 font-bold text-xs text-neutral-100 dark:bg-sky-600 dark:text-gray-300"
                 >
                     추가
                 </Button>

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -70,7 +70,7 @@ export default memo(function Search({ searchEnginesList, handleModal }: Props) {
             )}
             <Button
                 type="submit"
-                customStyle="w-24 h-full rounded-r-md bg-sky-400 font-bold text-sm text-neutral-100 dark:bg-sky-600 dark:text-gray-300 cursor-pointer shadow-none rounded-l-none"
+                customStyle="w-24 h-full rounded-r-md bg-sky-400 font-bold text-base text-neutral-100 dark:bg-sky-600 dark:text-gray-300 cursor-pointer shadow-none rounded-l-none"
             >
                 검색
             </Button>

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.12.0",
-    "sharp": "^0.33.2",
-    "suncalc": "^1.9.0"
+    "sharp": "^0.33.2"
   },
   "devDependencies": {
     "@types/crypto-js": "^4.2.1",
@@ -30,7 +29,6 @@
     "@types/node": "20.10.4",
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.17",
-    "@types/suncalc": "^1",
     "@yarnpkg/sdks": "^3.1.0",
     "autoprefixer": "^10.4.16",
     "eslint": "8.55.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "8.55.0",
     "eslint-config-next": "14.0.4",
     "postcss": "^8.4.32",
-    "tailwindcss": "^3.3.6",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"
   },
   "packageManager": "yarn@4.0.2"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.12.0",
-    "sharp": "^0.33.2"
+    "sharp": "^0.33.2",
+    "suncalc": "^1.9.0"
   },
   "devDependencies": {
     "@types/crypto-js": "^4.2.1",
@@ -29,6 +30,7 @@
     "@types/node": "20.10.4",
     "@types/react": "18.2.45",
     "@types/react-dom": "18.2.17",
+    "@types/suncalc": "^1",
     "@yarnpkg/sdks": "^3.1.0",
     "autoprefixer": "^10.4.16",
     "eslint": "8.55.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,5 +14,6 @@ module.exports = {
             ...defaultTheme.screens,
         },
     },
+    darkMode: 'selector',
     plugins: [],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,6 +1575,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/suncalc@npm:^1":
+  version: 1.9.2
+  resolution: "@types/suncalc@npm:1.9.2"
+  checksum: 3a2d3b48b5097b7dadc8f0782e5a47805fdf64b0d93d00dc51feb5a61117306dc78fd99f424afee9c9b263a0c38fe66644e50a823febbf6db578e61dcd41ccac
+  languageName: node
+  linkType: hard
+
 "@types/tough-cookie@npm:*":
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
@@ -6129,6 +6136,7 @@ __metadata:
     "@types/node": "npm:20.10.4"
     "@types/react": "npm:18.2.45"
     "@types/react-dom": "npm:18.2.17"
+    "@types/suncalc": "npm:^1"
     "@yarnpkg/sdks": "npm:^3.1.0"
     autoprefixer: "npm:^10.4.16"
     cookies-next: "npm:^4.1.0"
@@ -6145,6 +6153,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-icons: "npm:^4.12.0"
     sharp: "npm:^0.33.2"
+    suncalc: "npm:^1.9.0"
     tailwindcss: "npm:^3.4.1"
     typescript: "npm:^5.3.3"
   languageName: unknown
@@ -6310,6 +6319,13 @@ __metadata:
     sucrase: bin/sucrase
     sucrase-node: bin/sucrase-node
   checksum: b64d154a7a7eaa4b39668c3124bd08cd505f683d36ac4fb94def6491fb3af155b24b6e41b55011e38582e7d59c440af79ffba8709f3da78aeedf2f07b6d51d84
+  languageName: node
+  linkType: hard
+
+"suncalc@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "suncalc@npm:1.9.0"
+  checksum: ba24acf67a421fd96f1137d905540ec445834e8965573888c9fd4d7b94d6825051c8a6fcb11c9a4f1fb64042d3ddd51cdc992f0b7a5436714dd5faab18715d92
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,7 +6145,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-icons: "npm:^4.12.0"
     sharp: "npm:^0.33.2"
-    tailwindcss: "npm:^3.3.6"
+    tailwindcss: "npm:^3.4.1"
     typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
@@ -6336,9 +6336,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:^3.3.6":
-  version: 3.3.6
-  resolution: "tailwindcss@npm:3.3.6"
+"tailwindcss@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "tailwindcss@npm:3.4.1"
   dependencies:
     "@alloc/quick-lru": "npm:^5.2.0"
     arg: "npm:^5.0.2"
@@ -6365,7 +6365,7 @@ __metadata:
   bin:
     tailwind: lib/cli.js
     tailwindcss: lib/cli.js
-  checksum: 7cca9ce2d49696a9025f3426fcf1b2ca5c6bba4c8abad50c36d3dc0b87a09b2b89976a2053bab5c50b7d488d5e54fd7865b4d0bbe5cc82a829986b901715fb27
+  checksum: bf460657c674b1fb22ad7017ab5a9771c2884a3089d7767cee2395e8d9a54d74846170934ee00e285f39622c8e9e54d6f0e54bf38344efdc61544291c4d325c2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,13 +1575,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/suncalc@npm:^1":
-  version: 1.9.2
-  resolution: "@types/suncalc@npm:1.9.2"
-  checksum: 3a2d3b48b5097b7dadc8f0782e5a47805fdf64b0d93d00dc51feb5a61117306dc78fd99f424afee9c9b263a0c38fe66644e50a823febbf6db578e61dcd41ccac
-  languageName: node
-  linkType: hard
-
 "@types/tough-cookie@npm:*":
   version: 4.0.2
   resolution: "@types/tough-cookie@npm:4.0.2"
@@ -6136,7 +6129,6 @@ __metadata:
     "@types/node": "npm:20.10.4"
     "@types/react": "npm:18.2.45"
     "@types/react-dom": "npm:18.2.17"
-    "@types/suncalc": "npm:^1"
     "@yarnpkg/sdks": "npm:^3.1.0"
     autoprefixer: "npm:^10.4.16"
     cookies-next: "npm:^4.1.0"
@@ -6153,7 +6145,6 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-icons: "npm:^4.12.0"
     sharp: "npm:^0.33.2"
-    suncalc: "npm:^1.9.0"
     tailwindcss: "npm:^3.4.1"
     typescript: "npm:^5.3.3"
   languageName: unknown
@@ -6319,13 +6310,6 @@ __metadata:
     sucrase: bin/sucrase
     sucrase-node: bin/sucrase-node
   checksum: b64d154a7a7eaa4b39668c3124bd08cd505f683d36ac4fb94def6491fb3af155b24b6e41b55011e38582e7d59c440af79ffba8709f3da78aeedf2f07b6d51d84
-  languageName: node
-  linkType: hard
-
-"suncalc@npm:^1.9.0":
-  version: 1.9.0
-  resolution: "suncalc@npm:1.9.0"
-  checksum: ba24acf67a421fd96f1137d905540ec445834e8965573888c9fd4d7b94d6825051c8a6fcb11c9a4f1fb64042d3ddd51cdc992f0b7a5436714dd5faab18715d92
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🧑‍💻 PR 내용
- tailwindcss의 설정을 조정하여 다크모드를 수동으로 작동시키도록 수정했습니다.
- 다크모드 토글을 위한 버튼을 만들었습니다(위치: 사용자 정보 관리 메뉴)
- 쿠키에 테마 정보를 저장해 사용자가 다크모드를 설정하더라도 서버에서 이를 감지하지 못해 렌더링 직후 라이트 모드가 표시됐다가 다크모드로 전환되는 현상을 없앴습니다.

## 📸 스크린샷
![스크린샷 2024-02-27 오후 9 49 38](https://github.com/godcl1623/start-page/assets/20578093/0b09e4a6-8155-473b-b18d-3dcb77e2ae86)
![스크린샷 2024-02-27 오후 9 49 48](https://github.com/godcl1623/start-page/assets/20578093/9b0e4c5f-7e67-401d-b6f1-07d9bde3ea81)

## 🧐 논의할 점
- 현재 방식은 사용자가 한 번 테마 설정을 완료할 경우 SSR 수준에서 테마가 유지되고 있으나, 페이지에 최초로 접속했을 때 라이트모드만 표시되는 
단점이 존재합니다.
- SSR 시점에 서버 컴포넌트에서 사용자의 정보를 알 수 있으면 시간대에 따른 다크모드 / 라이트모드 적용을 통해 페이지에 최초로 접속하더라도 그에 맞는 테마를 보여줄 수 있으나 현재 Next.js 단독으로는 해당 기능의 적용이 불가능한 것으로 보입니다.
- 시간대에 따른 테마 적용을 위해 관련 내용에 대해 연구할 계획입니다.